### PR TITLE
Fix for Chrome

### DIFF
--- a/webcam-swiper-0.1.js
+++ b/webcam-swiper-0.1.js
@@ -15,7 +15,8 @@ function initializeWebcamSwiper() {
 
 		// Create a video element and set its source to the stream from the webcam
 		var videoElement = document.createElement("video");
-		videoElement.style.display = "none";
+		videoElement.style.position = "absolute";
+		videoElement.style.left = "-1000px";
 		videoElement.autoplay = true;
 		document.getElementsByTagName("body")[0].appendChild(videoElement);
 		if (window.URL === undefined) {
@@ -181,7 +182,7 @@ function initializeWebcamSwiper() {
 
 				return value / theData.length;
 			}
-		}, 1000);
+		}, 5000);
 	});
 }
 


### PR DESCRIPTION
I noticed that this didn't work on my browser, Chrome 22. I discovered that it was because the video was being hidden with display: none; which prevented later code from being able to read the size of the video element.

After I fixed that, I also noticed that sometimes the video element wasn't created quickly enough, which caused the same error. I assume you had the same issue and fixed it by waiting one second- I bumped this to 5 seconds.
