### PR TITLE
Wait longer after creating the video element

### DIFF
--- a/webcam-swiper-0.1.js
+++ b/webcam-swiper-0.1.js
@@ -181,7 +181,7 @@ function initializeWebcamSwiper() {
 
 				return value / theData.length;
 			}
-		}, 1000);
+		}, 5000);
 	});
 }
 


### PR DESCRIPTION
This didn't work on my computer until I bumped the timeout up to 5 seconds. I assume my older laptop takes a little time to get the webcam ready.
